### PR TITLE
fix: dialog re-render with key and improve feedback rendering condition

### DIFF
--- a/components/AddForms.tsx
+++ b/components/AddForms.tsx
@@ -76,8 +76,11 @@ export default function AddForms<T extends Record<string, any>>({
         })
         setTimeout(() => {
           setOpen({ open: false, type: mapTitleToType(title) });
-          onReload()
-        }, 2000);
+        }, 500);
+
+        setTimeout(() => {
+          onReload();
+        }, 1000);
       } else {
         const errorMessage =
           typeof data?.message === 'string'
@@ -99,7 +102,7 @@ export default function AddForms<T extends Record<string, any>>({
   };
 
   return (
-    <Dialog open={open.open} onOpenChange={(isOpen) => {
+    <Dialog key={open.type} open={open.open} onOpenChange={(isOpen) => {
       setOpen({ ...open, open: isOpen, type: mapTitleToType(title) });
       if (!isOpen) setEdit(null);
     }}

--- a/components/FormComponent.tsx
+++ b/components/FormComponent.tsx
@@ -35,7 +35,9 @@ export function FormComponent<T extends FieldValues>({ title, onSubmit, form, lo
                             )}
                         />
                     ))}
-                    {feedback && <FeedbackComponent message={feedback.message} type={feedback.type} />}
+                    {feedback?.message && (
+                        <FeedbackComponent message={feedback.message} type={feedback.type} />
+                    )}
                     {loading ? <MiniLoading /> : <Button className="cursor-pointer" type="submit">{'ENTRAR'}</Button>}
                 </form>
             </Form>


### PR DESCRIPTION
## This PR includes two targeted improvements:

1. 🛠️ Dialog Rendering Fix
  - Added a dynamic key (open.type) to the <Dialog> component to ensure proper re-rendering when the dialog type changes.
  - Adjusted setTimeout for reload to a more consistent behavior with two separate delays (500ms and 1000ms) for smoother transitions.
2. ✅ Feedback Component Rendering
  - Updated feedback condition to render FeedbackComponent only when feedback.message exists, preventing unnecessary renders or empty placeholders.

